### PR TITLE
Issue #60 fix regression for missing items in the user menu.

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -321,7 +321,7 @@ function local_envbar_user_menu($envs) {
         }
         $link = <<<EOD
 <li role="presentation">
-  <a class="icon menu-action no-envbar-highlight" role="menuitem" href="#">
+  <a class="icon menu-action no-envbar-highlight" role="menuitem" href="{$jump}">
     <span class="menu-action-text"> </span>
   </a>
 </li>


### PR DESCRIPTION
The missing menu items were caused with issue #47.

Since we now clean up the duplicate envbars in $CFG->additionalhtml when the settings page is saved. It does not matter that it shows up in the generic search results.

The renderer was previously creating the labels to the other sites based on the url that was available in the link. This will restore that link and label.