### PR TITLE
Issue #76: Make updatelastcheck and pingprod methods static

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ matrix:
   # Test with PHP 7.1
   - php: 7.1
     env: DB=pgsql MOODLE_BRANCH=master
+  # Moodle 3.4+ requires PHP 7.
+  exclude:
+  - php: 5.6
+  - MOODLE_BRANCH=master
 
 before_install:
 - cd ../..

--- a/classes/local/envbarlib.php
+++ b/classes/local/envbarlib.php
@@ -399,7 +399,7 @@ class envbarlib {
      *
      * @param int epoch to set prodlastcheck, current time by default
      */
-    public function updatelastcheck($time = null) {
+    public static function updatelastcheck($time = null) {
         // Update the prodlastcheck and clear the cache to make it effective.
         $time = is_null($time) ? time() : $time;
         set_config('prodlastcheck', $time, 'local_envbar');
@@ -413,7 +413,7 @@ class envbarlib {
      * @param bool $force if true do not check prodlastping
      * @param bool $debug print curl debug if true
      */
-    public function pingprod($force = false, $debug = false) {
+    public static function pingprod($force = false, $debug = false) {
         global $CFG;
 
         $config = get_config('local_envbar');

--- a/version.php
+++ b/version.php
@@ -29,8 +29,8 @@ if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
 }
 
-$plugin->version   = 2017062800;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2017062800;      // Same as version
+$plugin->version   = 2017072100;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2017072100;      // Same as version
 $plugin->requires  = 2014051200;      // Requires Moodle 2.7 or later.
 $plugin->component = "local_envbar";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
    - This prevents PHP deprecated warnings when sync_lastrefresh
      attempts to call these methods statically.
    - The envbarlib class is not instantiated anywhere in the
      plugin code.