### PR TITLE
Changes to label and help text for non prod environment URL

### DIFF
--- a/lang/en/local_envbar.php
+++ b/lang/en/local_envbar.php
@@ -67,6 +67,6 @@ $string['showtext'] = 'Text to show';
 $string['showtextplaceholder'] = 'eg: You are on staging environment';
 $string['textcolour'] = 'Foreground colour';
 $string['urlmatch'] = 'Non Production URL';
-$string['urlmatch_help'] = 'Add the address for your non prod site. Note: You can use Regular Expressions to match your URL.<br />E.g. http://stage[1,2,3].example.com to match http://stage2.example.com<br />Note that following special characters will be escaped:<br /> / \ - . ? * ^ $';
+$string['urlmatch_help'] = 'Add the address for your non prod site.<br />Note: You can use Regular Expressions to match your URL.<br />E.g. http://stage[1,2,3].example.com to match http://stage2.example.com<br />Note that following special characters will be escaped:<br /> / \ - . ? * ^ $';
 $string['urlmatchplaceholder'] = 'eg. staging';
 

--- a/lang/en/local_envbar.php
+++ b/lang/en/local_envbar.php
@@ -66,7 +66,7 @@ $string['setdeleted'] = 'Delete';
 $string['showtext'] = 'Text to show';
 $string['showtextplaceholder'] = 'eg: You are on staging environment';
 $string['textcolour'] = 'Foreground colour';
-$string['urlmatch'] = 'URL Match pattern';
-$string['urlmatch_help'] = 'You can use Regular Expressions to match your URL.<br />E.g. http://stage[1,2,3].example.com to match http://stage2.example.com<br />Note that following special characters will be escaped:<br /> / \ - . ? * ^ $';
+$string['urlmatch'] = 'Non Production URL';
+$string['urlmatch_help'] = 'Add the address for your non prod site. Note: You can use Regular Expressions to match your URL.<br />E.g. http://stage[1,2,3].example.com to match http://stage2.example.com<br />Note that following special characters will be escaped:<br /> / \ - . ? * ^ $';
 $string['urlmatchplaceholder'] = 'eg. staging';
 


### PR DESCRIPTION
When attempting to configure env bar for a client, I found the "URL PATTERN MATCH" label a bit confusing, and was uncertain what I should put in the field, or how to do a regular expression.

I reviewed a different client site to see what was there, and saw it simply contained the URL for staging. I think this change makes it clearer, but am happy to discuss alternatives, or update associated documentation instead.

I'm also not clear how staging gets the update from prod config.  Is that via cron?