### PR TITLE
Fix typo with class name

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -167,7 +167,7 @@ EOD;
 
         if ($fixed) {
             $js .= <<<EOD
-    document.body.className += ' local_envbar local_envarbar_$envclass';
+    document.body.className += ' local_envbar local_envbar_$envclass';
 EOD;
         }
 


### PR DESCRIPTION
I expect that this is a typo which I just fixed. If this classname was written that way by purpose for unknown reason, just close this pull request.