### PR TITLE
Adding missing PHPDoc

### DIFF
--- a/classes/local/envbarlib.php
+++ b/classes/local/envbarlib.php
@@ -47,10 +47,25 @@ if (!defined('MOODLE_INTERNAL')) {
  */
 class envbarlib {
 
+    /**
+     * Constant string variable - <!-- ENVBARSTART -->
+     *
+     * @var string
+     */
     const ENVBAR_START = '<!-- ENVBARSTART -->';
 
+    /**
+     * Constant string variable - <!-- ENVBAREND -->
+     *
+     * @var string
+     */
     const ENVBAR_END = '<!-- ENVBAREND -->';
 
+    /**
+     * Boolean to check that hold status if inject has been called
+     *
+     * @var boolean
+     */
     private static $injectcalled = false;
 
     /**
@@ -453,7 +468,7 @@ CSS;
     /**
      * Sets prodlastcheck with the current or a passed time.
      *
-     * @param int epoch to set prodlastcheck, current time by default
+     * @param string $time current time by default
      */
     public static function updatelastcheck($time = null) {
         // Update the prodlastcheck and clear the cache to make it effective.

--- a/renderer.php
+++ b/renderer.php
@@ -311,6 +311,7 @@ EOD;
 /**
  * Gets some JS which adds the env to the page title
  *
+ * @param object $match
  * @return string A chunk of JS to set the title
  */
 function local_envbar_title($match) {
@@ -334,6 +335,7 @@ EOD;
 /**
  * Gets some JS which colorizes the favicon according to the env
  *
+ * @param object $match
  * @return string A chunk of JS to set the favicon
  */
 function local_envbar_favicon_js($match) {
@@ -390,6 +392,7 @@ EOD;
 /**
  * Gets some JS which inserts env jump links into the user menu
  *
+ * @param array $envs
  * @return string A chunk of JS
  */
 function local_envbar_user_menu($envs) {

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -27,6 +27,9 @@ use local_envbar\local\envbarlib;
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden');
 
+/**
+ * Unit testing class for envbar_lib
+ */
 class local_envbar_lib_test extends advanced_testcase {
 
     /**

--- a/tests/privacy/privacy.php
+++ b/tests/privacy/privacy.php
@@ -99,9 +99,9 @@ echo "\n\n== Done ==\n";
 
 /**
  * Test
- * @param $component
- * @param $interface
- * @return
+ * @param string $component
+ * @param object $interface
+ * @return mixed
  */
 function check_implements($component, $interface) {
         $manager = new \core_privacy\manager();


### PR DESCRIPTION
```
Run moodle-plugin-ci phpdoc
 RUN  Moodle PHPDoc Checker on local_envbar
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/last_refresh.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/classes/privacy/provider.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/classes/task/sync_lastrefresh.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/classes/local/envbarlib.php
    Line 54: Variable envbarlib::$injectcalled is not documented
    Line 50: Constant envbarlib::ENVBAR_START is not documented
    Line 52: Constant envbarlib::ENVBAR_END is not documented
    Line 456: Phpdocs for function envbarlib::updatelastcheck has incomplete parameters list
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/classes/form/config.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/classes/form/lastrefresh.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/db/upgrade.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/db/caches.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/db/tasks.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/settings.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/lib.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/version.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/toggle_debugging.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/lang/en/local_envbar.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/tests/privacy/privacy.php
    Line 102: Phpdocs for function check_implements has incomplete parameters list
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/tests/lib_test.php
    Line 30: Class local_envbar_lib_test is not documented
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/index.php
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/renderer.php
    Line 311: Phpdocs for function local_envbar_title has incomplete parameters list
    Line 334: Phpdocs for function local_envbar_favicon_js has incomplete parameters list
    Line 390: Phpdocs for function local_envbar_user_menu has incomplete parameters list
/home/runner/work/moodle-local_envbar/moodle-local_envbar/moodle/local/envbar/service/updatelastrefresh.php
Error: Process completed with exit code 1.
```