### PR TITLE
Add mtrace for unset prod wwwroot, update conditional flag

### DIFF
--- a/classes/local/envbarlib.php
+++ b/classes/local/envbarlib.php
@@ -472,6 +472,7 @@ CSS;
 
         // Skip if prodwwwroot hasn't been set.
         if (empty($prodwwwroot)) {
+            mtrace("Error, the production wwwroot has not been set.");
             return;
         }
 

--- a/last_refresh.php
+++ b/last_refresh.php
@@ -43,7 +43,7 @@ if ($data = $form->get_data()) {
     if (isset($data->pingprod)) {
         ob_start();
         envbarlib::pingprod(true, $verbose);
-        $debug = ob_get_contents();
+        $pingoutput = ob_get_contents();
         ob_clean();
     } else {
         redirect(new moodle_url('/local/envbar/last_refresh.php'), get_string('changessaved'));
@@ -54,29 +54,31 @@ if ($data = $form->get_data()) {
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('header_envbar', 'local_envbar'));
 echo $form->display();
-if (isset($debug)) {
+if ($verbose) {
     // The curl debug is a var_dump of the variables, so we need to do a regex to retrieve them.
     $commonstr = "<font color='#888a85'>=&gt;<\/font> <small>string<\/small> <font color='#cc0000'>'";
     $commonint = "<font color='#888a85'>=&gt;<\/font> <small>int<\/small> <font color='#4e9a06'>";
     $matches = array();
 
     $regex = "/'http_code' {$commonint}(.*?)<\/font>/s";
-    $preg = preg_match($regex, $debug, $matches);
+    $preg = preg_match($regex, $pingoutput, $matches);
     $httpcode = $matches[1];
     echo "<h1>HTTP code</h1>";
     echo "<pre>{$httpcode}</pre>";
 
     $regex = "/'CURLOPT_URL' {$commonstr}(.*?)'/s";
-    $preg = preg_match($regex, $debug, $matches);
+    $preg = preg_match($regex, $pingoutput, $matches);
     $curlurl = $matches[1];
     $regex = "/'CURLOPT_POSTFIELDS' {$commonstr}(.*?)'/s";
-    $preg = preg_match($regex, $debug, $matches);
+    $preg = preg_match($regex, $pingoutput, $matches);
     $postfields = $matches[1];
 
     echo "<h1>Curl command</h1>";
     echo "<pre>curl \"{$curlurl}?{$postfields}\"</pre>";
 
-    echo $debug;
+    echo $pingoutput;
+} else {
+    echo $pingoutput;
 }
 echo $OUTPUT->footer();
 


### PR DESCRIPTION
Resolves #174

- Renamed debug to pingoutput as it didn't always contain debug information and might contain the response->message in an mtrace.
- Updated conditional to be against the $verbose bool instead of the previous $debug variable which contained the output of the result. This was causing it to, 1. not show an issue when there was one, and 2. never show the result whether or not it was successful, which whilst not being 'verbose' per say, is still useful to know