### PR TITLE
Add different 'text to show' behaviour for smaller devices

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -74,12 +74,21 @@ class local_envbar_renderer extends plugin_renderer_base {
     left: 0px;
     z-index: 9999;
 }
-
+.envbar .showtext {
+    display: inline-block;
+}
 @media screen and (max-width: 700px) {
     .envbar {
         font-size: 12px;
         line-height: 12px;
         padding: 10px;
+    }
+    .envbar .showtext {
+        display: block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 
@@ -132,7 +141,7 @@ EOD;
         $class .= $fixed ? ' fixed' : '';
 
         // Show the configured env message.
-        $showtext = format_string(htmlspecialchars($match->showtext));
+        $showtext = \html_writer::tag('div', format_string(htmlspecialchars($match->showtext)), ['class' => 'showtext']);
 
         // Just show the biggest time unit instead of 2.
         if (!isset($config->stringseparator)) {


### PR DESCRIPTION
Resolves #25

At smaller device sizes:
- No longer wraps 
- Changes the overflowing content into ellipsis
- Pushes the action links onto the next line

Result looks like the following
![image](https://user-images.githubusercontent.com/9924643/120976617-db77c680-c7b5-11eb-891b-549d0368aa8d.png)
