### PR TITLE
Do not override config settings on WS calls (VERSION3)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -49,7 +49,7 @@ function local_envbar_before_standard_top_of_body_html() {
  */
 function local_envbar_after_config() {
     // Hack to avoid breaking messaging tests, as this setting defaults on.
-    if (!PHPUNIT_TEST) {
+    if (!PHPUNIT_TEST && !WS_SERVER) {
         try {
             envbarlib::config();
         } catch (Exception $e) {        // @codingStandardsIgnoreStart


### PR DESCRIPTION
This is to fix #190 