### PR TITLE
[#203] always return string prodwwwroot

### DIFF
--- a/classes/local/envbarlib.php
+++ b/classes/local/envbarlib.php
@@ -380,9 +380,9 @@ CSS;
      * This also base64_dencodes the value to obtain it.
      *
      * @return string $prodwwwroot if it is set either in plugin config via UI or
-     *         in config.php. Returns nothing if prodwwwroot is net set anywhere.
+     *         in config.php. Returns an empty string if prodwwwroot is not set anywhere.
      */
-    public static function getprodwwwroot() {
+    public static function getprodwwwroot(): string {
         global $CFG;
 
         $prodwwwroot = base64_decode(get_config("local_envbar", "prodwwwroot"));
@@ -394,6 +394,9 @@ CSS;
         if ($prodwwwroot) {
             return $prodwwwroot;
         }
+
+        // Not set - return empty string.
+        return '';
     }
 
     /**


### PR DESCRIPTION
Closes #203 

Problem was caused `getprodwwroot` returning void/null if no config was set, which was passed directly into rtrim causing the debugging error:

https://github.com/catalyst/moodle-local_envbar/blob/b21b951c10f1ff7e72b48cde4223f3b3f0770374/classes/local/envbarlib.php#L365

Fixed by returning empty string if not set. I checked other usages of `getprodwwwroot` and none of them should have issues with this.
