### PR TITLE
Fix deprecated base64_encode with null

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -264,7 +264,7 @@ EOD;
         $debugging = envbarlib::get_debugging_status_string();
         if ($canedit) {
             // Get the url of the current page.
-            $currentlink = $ME;
+            $currentlink = $ME ?? '/';
             $debugtogglelink = html_writer::link(
                 new moodle_url('/local/envbar/toggle_debugging.php',
                     ['redirect' => base64_encode($currentlink), 'sesskey' => sesskey()] ),


### PR DESCRIPTION
Fixes 
`Deprecated: base64_encode(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/site/local/envbar/renderer.php on line 270` When running tests