### PR TITLE
Change hook callback to string

### DIFF
--- a/db/hooks.php
+++ b/db/hooks.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
-        'callback' => [\local_envbar\hook_callbacks::class, 'before_standard_top_of_body_html_generation'],
+        'callback' => '\local_envbar\hook_callbacks::before_standard_top_of_body_html_generation',
         'priority' => 0,
     ],
 ];

--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2024052000;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024052000;      // Same as version
+$plugin->version   = 2024052400;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024052400;      // Same as version
 $plugin->requires  = 2014051200;      // Requires Moodle 2.7 or later.
 $plugin->component = 'local_envbar';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Changes the new hook callback back to a string for greater compatibility as it was causing some issues in 4.3, for example https://github.com/catalyst/moodle-auth_outage/issues/336