### PR TITLE
Remove unnecessary dynamic properties #213

### DIFF
--- a/classes/check/envage.php
+++ b/classes/check/envage.php
@@ -39,15 +39,6 @@ use local_envbar\local\envbarlib;
 class envage extends check {
 
     /**
-     * Constructor
-     */
-    public function __construct() {
-        global $CFG;
-        $this->id = 'envage';
-        $this->name = get_string('checkenvage', 'local_envbar');
-    }
-
-    /**
      * A link to a place to action this
      *
      * @return \action_link|null


### PR DESCRIPTION
PHP 8.2+ deprecation of dynamic properties.

$this->id and $this->name are references to old properties of check that were removed shortly after being added in MDL-67818, so these aren't being called from anywhere else and can be safely removed.

Closes #213 