### PR TITLE
issue#225 do not add environment swapper menu item by default

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -83,7 +83,7 @@ if ($hassiteconfig) {
     $presentation->add(new admin_setting_configcheckbox('local_envbar/enablemenu',
             get_string('enablemenu', 'local_envbar', null, true),
             get_string('enablemenu_desc', 'local_envbar', null, true),
-            true));
+            false));
 
     $presentation->add(new admin_setting_heading('local_envbar/linksheading',
             get_string('linksheading', 'local_envbar', null, true),

--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2024112000;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024112000;      // Same as version
+$plugin->version   = 2025011700;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2025011700;      // Same as version
 $plugin->requires  = 2024100700;      // Requires Moodle 4.5 or later.
 $plugin->component = 'local_envbar';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Regards https://github.com/catalyst/moodle-local_envbar/issues/225