### PR TITLE
Version in MOODLE_405_STABLE should be greater than VERSION3

### DIFF
--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2024112000;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024112000;      // Same as version
+$plugin->version   = 2025011700;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2025011700;      // Same as version
 $plugin->requires  = 2024100700;      // Requires Moodle 4.5 or later.
 $plugin->component = 'local_envbar';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Currently the version of MOODLE_405_STABLE is 2024112000, which is lower than the one in VERSION3 (2024112001).

This will cause downgrade error when switching from VERSION3 to MOODLE_405_STABLE, hence I bump the version.

https://github.com/catalyst/moodle-local_envbar/blob/VERSION3/version.php