### PR TITLE
Default enablemenu setting to false when PHPUNIT_TEST

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -80,10 +80,13 @@ if ($hassiteconfig) {
             get_string('menuheading', 'local_envbar', null, true),
             ''));
 
+    // This setting defaults to false only in PHPUnit tests.
+    // We do this because \core\user_menu_test::test_custom_user_menu() expect a certain number of user menu items.
+    // The test doesn't account for plugins, future test may not account for this too.
     $presentation->add(new admin_setting_configcheckbox('local_envbar/enablemenu',
             get_string('enablemenu', 'local_envbar', null, true),
             get_string('enablemenu_desc', 'local_envbar', null, true),
-            true));
+            PHPUNIT_TEST ? false : true));
 
     $presentation->add(new admin_setting_heading('local_envbar/linksheading',
             get_string('linksheading', 'local_envbar', null, true),

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -41,6 +41,9 @@ class lib_test extends \advanced_testcase {
 
         require_once($CFG->dirroot . '/local/envbar/lib.php');
 
+        // Switch on for envbar unit tests.
+        set_config('enablemenu', true, 'local_envbar');
+
         parent::setup();
         $this->resetAfterTest(true);
     }
@@ -77,6 +80,17 @@ class lib_test extends \advanced_testcase {
             array('https://my_moodle6.com/', '\D', false),
             array('\-/.?*+^$', '\-/.?*+^$', true),
         );
+    }
+
+    /**
+     * The env swapper feature introduced in issue #215 can cause core unit tests to fail. The setting is enablemenu is switched to
+     * off for unit testing. Test that it's been switched on for these unit tests.
+     */
+    public function test_usermenu_has_been_set_to_true_in_setup() {
+        $config = get_config('local_envbar');
+
+        $this->assertNotEmpty($config->enablemenu);
+        $this->assertTrue((bool) $config->enablemenu);
     }
 
     /**


### PR DESCRIPTION
Resolves failing core unit tests \core\user_menu_test::test_custom_user_menu() which expects only 3 user menu item.

Here is the failing unit test:
 - https://github.com/moodle/moodle/blob/cd6600da14290f2ab097aba8ce9d107e21c21fff/lib/tests/user_menu_test.php#L75-L110

<details>
<summary>Here is the failing unit tests output before</summary>
<br>
<pre>
There were 17 failures:

1) core\user_menu_test::test_custom_user_menu with data set #0 ('###', 0, 1)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

2) core\user_menu_test::test_custom_user_menu with data set #1 ('#####', 0, 1)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

3) core\user_menu_test::test_custom_user_menu with data set #2 ('-----', 0, 0)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

4) core\user_menu_test::test_custom_user_menu with data set #3 ('_____', 0, 0)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

5) core\user_menu_test::test_custom_user_menu with data set #4 ('test', 0, 0)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

6) core\user_menu_test::test_custom_user_menu with data set #5 ('#Garbage#', 0, 0)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

7) core\user_menu_test::test_custom_user_menu with data set #6 ('privatefiles,/user/files.php', 0, 0)
Failed asserting that actual size 4 matches expected size 3.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

8) core\user_menu_test::test_custom_user_menu with data set #7 ('#my1files,moodle|/user/files.php', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

9) core\user_menu_test::test_custom_user_menu with data set #8 ('#my1files,moodleakjladf|/user...es.php', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

10) core\user_menu_test::test_custom_user_menu with data set #9 ('#my1files,a/b|/user/files.php', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

11) core\user_menu_test::test_custom_user_menu with data set #10 ('#my1files,#b|/user/files.php', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

12) core\user_menu_test::test_custom_user_menu with data set #11 ('-|-|-|-', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

13) core\user_menu_test::test_custom_user_menu with data set #12 ('-|-|-', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

14) core\user_menu_test::test_custom_user_menu with data set #13 ('-|-', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

15) core\user_menu_test::test_custom_user_menu with data set #14 ('#f234|2', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

16) core\user_menu_test::test_custom_user_menu with data set #15 ('messages,message|/message/index.php', 1, 1)
Failed asserting that actual size 5 matches expected size 4.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76

17) core\user_menu_test::test_custom_user_menu with data set #16 ('messages,message|/message/ind...f234|2', 5, 3)
Failed asserting that actual size 9 matches expected size 8.

/var/www/site/lib/tests/user_menu_test.php:106
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76
</pre>
</details>

Here is how to run the specific core test:
```
vendor/bin/phpunit lib/tests/user_menu_test.php --filter '^.*::test_custom_user_menu( .*)?$'
```