### PR TITLE
Fix check refresh timestamp unit test #243

### DIFF
--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -327,7 +327,7 @@ class lib_test extends \advanced_testcase {
 
         // Confirm the calculated refresh time is in the future when the relative strtotime returns a past date.
         $env->refreshschedule = 'second sunday of this month 12 pm';
-        $this->assertEquals(strtotime('2025-03-09 12:00:00'), strtotime($env->refreshschedule));
+        $this->assertEquals(strtotime('2025-03-09 12:00:00'), strtotime($env->refreshschedule, $lastrefresh));
         envbarlib::update_envbar(clone $env);
         envbarlib::check_refresh_timestamp();
         $this->assertEquals(strtotime('2025-04-13 12:00:00'), get_config('local_envbar', 'nextrefreshasts'));


### PR DESCRIPTION
Logic error with the unit test that didn't set the base timestamp, so the test previously passed in March but failed in April.

Closes #243 