### PR TITLE
Issue 164: Stop html inject when in Behat test

### DIFF
--- a/classes/local/envbarlib.php
+++ b/classes/local/envbarlib.php
@@ -423,7 +423,9 @@ CSS;
      *
      */
     public static function injection_allowed() {
-        global $PAGE;
+        global $PAGE, $CFG;
+
+        require_once($CFG->libdir . '/behat/lib.php');
 
         if (self::$injectcalled) {
             return false;
@@ -431,6 +433,11 @@ CSS;
 
         // Do not inject if being called in an ajax or cli script unless it's a unit test.
         if ((CLI_SCRIPT || AJAX_SCRIPT) && !PHPUNIT_TEST) {
+            return false;
+        }
+
+        // Do not inject if in behat test.
+        if (behat_is_test_site()) {
             return false;
         }
 


### PR DESCRIPTION
Have noticed that there are random Behat tests all over core Moodle failing because the envbar is getting in the way.  As the plugin itself has no behat tests should we just not have it inject when in a behat test?